### PR TITLE
Replace priority input with dropdown list in copilot feedback issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/copilot_enterprise_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/copilot_enterprise_feedback.yml
@@ -19,12 +19,17 @@ body:
     validations:
       required: true
 
-  - type: input
+  - type: dropdown
     id: priority
     attributes:
       label: Priority
-      description: "Enter the priority of the feedback"
-      placeholder: "High, Medium, Low"
+      description: "Select the priority of the feedback"
+      options:
+        - Minor
+        - Medium
+        - Major
+        - Blocker
+        - Bug
     validations:
       required: true
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ test
 This template is used to report feedback for Copilot Enterprise. It includes the following inputs:
 
 - Date
-- Priority
+- Priority (dropdown list: Minor, Medium, Major, Blocker, Bug)
 - Objective/Use Case
 - Metadata (language, taille du repo, …)
 - Interaction (chat, PR, KB, ..)
@@ -60,12 +60,17 @@ body:
     validations:
       required: true
 
-  - type: input
+  - type: dropdown
     id: priority
     attributes:
       label: Priority
-      description: "Enter the priority of the feedback"
-      placeholder: "High, Medium, Low"
+      description: "Select the priority of the feedback"
+      options:
+        - Minor
+        - Medium
+        - Major
+        - Blocker
+        - Bug
     validations:
       required: true
 


### PR DESCRIPTION
Related to #29

Replace the priority input in the copilot feedback issue template with a dropdown list.

* **README.md**
  - Update the priority input description to indicate it is now a dropdown list with options: Minor, Medium, Major, Blocker, Bug.
  - Modify the example usage to reflect the dropdown list for priority.

* **.github/ISSUE_TEMPLATE/copilot_enterprise_feedback.yml**
  - Replace the priority input field with a dropdown list.
  - Add the options: Minor, Medium, Major, Blocker, Bug to the dropdown list.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tdupoiron-org/demo-actions/issues/29?shareId=13352281-b3f2-4ac5-b531-fb004e0c6665).